### PR TITLE
Fix bug with caching simple schema global messages

### DIFF
--- a/shared/lib.js
+++ b/shared/lib.js
@@ -1,6 +1,5 @@
 if (Meteor.isClient) {
   Meteor.startup(function() {
-    var globalMessages = _.clone(SimpleSchema._globalMessages);
     Meteor.autorun(function() {
       var lang = TAPi18n.getLanguage();
       var localMessages = TAPi18n.__("simpleschema.messages", { returnObjectTrees: true });
@@ -8,7 +7,7 @@ if (Meteor.isClient) {
         if (item.exp) item.exp = eval(item.exp);
         return item;
       });
-      var messages = _.extend(_.clone(globalMessages), localMessages);
+      var messages = _.extend(_.clone(SimpleSchema._globalMessages), localMessages);
       SimpleSchema.messages(messages);
     });
   });


### PR DESCRIPTION
The problem occurs when you reactively change the (simple schema) global messages to different translations.
Since your code caches them only at startup time (outside of the autorun) the (old) cached version is used in all
following invocations, thus overriding the new values. A temporary fix in our project was to wrap our autorun
(which updates our custom translations) with Meteor.startup, so that they always run after yours.